### PR TITLE
Fixing .env.production API URL

### DIFF
--- a/example/bflobox/.env.production
+++ b/example/bflobox/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_BFLOBOX_API_URL="localhost:8080"
+REACT_APP_BFLOBOX_API_URL="https://api.bflobox.com"


### PR DESCRIPTION
### Overview
<!-- A summary of changes being introduced -->

URL was still pointing to `localhost:8080` 😝 